### PR TITLE
translation: add pt-BR

### DIFF
--- a/i18n/pt-BR/code.json
+++ b/i18n/pt-BR/code.json
@@ -1,0 +1,14 @@
+{
+  "pages.callback.success.title": {
+    "message": "Autenticação bem-sucedida"
+  },
+  "pages.callback.success.copyCode": {
+    "message": "Por favor copie o código de autorização abaixo e cole ele na página de opções."
+  },
+  "pages.callback.failure.title": {
+    "message": "Autenticação falha"
+  },
+  "pages.callback.failure.checkError": {
+    "message": "Verifique a mensagem de erro abaixo."
+  }
+}

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/getting-started.md
@@ -1,0 +1,54 @@
+---
+title: Primeiros passos
+sidebar_position: 1
+---
+
+## Instalação
+
+Você pode instalar o uBlacklist da [Chrome Web Store](https://chrome.google.com/webstore/detail/ublacklist/pncfbmialoiaghdehhbnbhkkgmjanfhe/), [Firefox Add-ons](https://addons.mozilla.org/en/firefox/addon/ublacklist/), ou da [App Store](https://apps.apple.com/us/app/ublacklist-for-safari/id1547912640).
+
+:::note
+
+O uBlacklist requer várias permissões de sites na instalação. Estas permissões são necessárias para o suporte em todos os domínios em que a busca do Google é fornecida (ex: google.com, google.com.br, ...).
+
+:::
+
+## Bloquear um site na página de resultados de busca {#block-site-in-search-result-page}
+
+Para bloquear um site na página de resultados de busca, clique no botão do ícone no resultado de busca.
+
+![block link](/img/getting-started/block-1.png)
+
+Um diálogo "Bloquear este site" vai aparecer. Clique no botão "Bloquear".
+
+![block dialog](/img/getting-started/block-2.png)
+
+Depois disso, o site bloqueado não vai mais aparecer na página de resultados de busca.
+
+Se você clicar no ícone da barra de ferramentas e ativar a opção "Mostrar resultados de busca bloqueados", os sites bloqueados vão aparecer temporariamente.
+
+![show blocked site](/img/getting-started/block-3.png)
+
+Para desbloquear um site bloqueado, clique no botão do ícone de novo.
+
+No Chrome, o ícone da barra de ferramentas pode estar oculto por padrão, se este for o caso, clique primeiro no ícone de pedaço de quebra-cabeça para que ele apareça.
+
+![hidden toolbar icon](/img/getting-started/block-4.png)
+
+## Bloquear um site atual {#block-current-site}
+
+Para bloquear um site que você está visualizando no momento de aparecer na página de resultados de busca, clique no botão na barra de ferramentas. Um diálogo "Bloquear este site" vai aparecer.
+
+![toolbar icon](/img/getting-started/block-current.png)
+
+Para desbloquear um site bloqueado, clique no ícone da barra de ferramentas de novo.
+
+## Editar sites bloqueados {#edit-blocked-sites}
+
+Para visualizar e editar sites bloqueados, abra a página de opções. Você pode acessá-la pelo ícone da barra de ferramentas.
+
+![options link](/img/getting-started/options-1.png)
+
+Os sites bloqueados vão aparecer no topo da página de opções. Depois de editar eles, não se esqueça de clicar no botão de "Salvar".
+
+![blocked sites](/img/getting-started/options-2.png)

--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/introduction.md
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/introduction.md
@@ -1,0 +1,27 @@
+---
+title: Introdução
+sidebar_position: 0
+slug: /
+---
+
+uBlacklist is a browser extension that filters Google Search results, available for Chrome, Firefox, and Safari.
+O uBlacklist é uma extensão de navegador que filtra resultados da busca do Google, e está disponível pro Chrome, pro Firefox, e pro Safari.
+
+- [Chrome Web Store](https://chrome.google.com/webstore/detail/ublacklist/pncfbmialoiaghdehhbnbhkkgmjanfhe/)
+- [Firefox Add-ons](https://addons.mozilla.org/en/firefox/addon/ublacklist/)
+- [App Store](https://apps.apple.com/us/app/ublacklist-for-safari/id1547912640) (cuidado por [Group-Leafy](https://github.com/HoneyLuka/uBlacklist/tree/safari-port/safari-project))
+- [GitHub](https://github.com/iorate/ublacklist)
+
+## Demonstração {#demo}
+
+![Demo](/img/demo.gif)
+
+## Recursos {#features}
+
+- Bloqueie completamente sites indesejados de aparecer nos resultados de busca
+- Bloqueie sites usando URLs específicos usando match patterns e expressões regulares
+- Bloqueie sites usando títulos específicos usando expressões regulares
+- Destaque sites preferidos nos resultados de busca
+- Suporte pro Bing, Brave, DuckDuckGo, Ecosia, SearXNG, Startpage.com, Yahoo! JAPAN, e Yandex
+- Sincronize conjuntos de regras entre dispositivos usando o Google Drive ou o Dropbox
+- Se inscreva em conjuntos de regras públicos

--- a/i18n/pt-BR/docusaurus-plugin-content-pages/privacy-policy.md
+++ b/i18n/pt-BR/docusaurus-plugin-content-pages/privacy-policy.md
@@ -1,0 +1,16 @@
+---
+title: Política de privacidade
+---
+
+# Política de privacidade
+- O uBlacklist **não** coleta sua informação pessoal.
+- O uBlacklist utiliza da autenticação do Google **somente** para salvar suas configurações no Google Drive.
+- O uBlacklist utiliza da autenticação do Dropbox **somente** para salvar suas configurações no Dropbox.
+
+<!--
+:::note
+
+No evento de uma divergência entre a [versão em Inglês](pathname://../privacy-policy) e esta versão traduzida, a versão em Inglês deve prevanecer, ter prioridade.
+
+:::
+-->

--- a/i18n/pt-BR/docusaurus-plugin-content-pages/subscriptions.md
+++ b/i18n/pt-BR/docusaurus-plugin-content-pages/subscriptions.md
@@ -1,0 +1,125 @@
+---
+title: Inscrições
+---
+
+:::warning[Alerta]
+
+As listas de bloqueio destacadas nesta página são conteúdo gerado pelo usuário, e não são aprovadas, controladas, ou verificadas pelo projeto do uBlacklist. Estas listas são criadas e mantidas por colaboradores independentes baseado em revisões e avaliações independentes. Por causa disto, elas refletem as opiniões e julgamentos dos seus respectivos autores. O projeto em si se mantém neutro e simplemente fornece uma plataforma para que estas listas sejam compartilhadas. Os usuários devem utilizar de seus próprios critérios ao escolher aplicar estas listas de bloqueio. Se qualquer problema ou preocupação surgir com uma lista específica, os usuários devem relatar elas diretamente ao criador da lista.
+
+:::
+
+:::note
+
+Os títulos das listas foram mantidos em Inglês por simplicidade mas também para honrar o possível desejo da não tradução deles.
+
+:::
+
+# Inscrições
+
+[Adicione a sua inscrição](https://github.com/ublacklist/website/edit/main/src/pages/subscriptions.md)
+
+
+## Conteúdo gerado por IA {#ai-generated-content}
+
+- [ublacklist-ai](https://github.com/PrincessAkira/ublacklist-ai) por [Sarah Engel](https://github.com/PrincessAkira)
+  - "Block those pesky AI-Art things on Google Images to make searching for Backgrounds or Images enjoyable again."
+- [uBlockOrigin & uBlacklist Huge AI Blocklist](https://github.com/laylavish/uBlockOrigin-HUGE-AI-Blocklist) por [laylavish](https://github.com/laylavish)
+  - "A huge blocklist of sites that contain AI generated content for uBlock Origin & uBlacklist."
+
+## Sites imitadores {#copycat-sites}
+
+- [uBlacklist GitHub Translation](https://github.com/arosh/ublacklist-github-translation) por [Sho Iizuka](https://github.com/arosh)
+  - "Exclude domains that serve machine-translated pages of READMEs, Issues, Pull requests, etc. on GitHub from Google search."
+- [uBlacklist Stack Overflow Translation](https://github.com/arosh/ublacklist-stackoverflow-translation) por [Sho Iizuka](https://github.com/arosh)
+  - "Filter that enables excluding the machine-translated sites of Stack Overflow."
+- [uBlock-Origin-dev-filter](https://github.com/quenhus/uBlock-Origin-dev-filter) por [quenhus](https://github.com/quenhus)
+  - "Filters to block and remove copycat-websites from DuckDuckGo, Google and other search engines. Used to be specific to dev websites like StackOverflow or GitHub, but it currently supports others like Wikipedia."
+
+## Sites da mídia {#media-sites}
+
+- [Axel Springer SE blacklist](https://github.com/RubenKelevra/ublacklist_springer) por [RubenKelevra](https://github.com/RubenKelevra)
+  - "Hides all Axel Springer SE media outlets, including mentiones/topics on other sides"
+- [Conspiracy Media blacklist](https://github.com/RubenKelevra/ublacklist_conspiracy) por [RubenKelevra](https://github.com/RubenKelevra)
+  - "Hides (most) conspiracy media outlets"
+- [Fake-News Media blacklist](https://github.com/RubenKelevra/ublacklist_fakenews) por [RubenKelevra](https://github.com/RubenKelevra)
+  - "Hides (most) fake news media outlets"
+- [Leftwing Media blacklist](https://github.com/RubenKelevra/ublacklist_leftwing_media) por [RubenKelevra](https://github.com/RubenKelevra)
+  - "Hides (most) leftwing media outlets"
+- [Rightwing Media blacklist](https://github.com/RubenKelevra/ublacklist_rightwing_media) por [RubenKelevra](https://github.com/RubenKelevra)
+  - "Hides (most) rightwing media outlets"
+- [Israeli News Blocklist](https://github.com/punpunie/ilNewsBlocklist) por [bun](https://github.com/punpunie)
+  - "blocklist of english-speaking israeli news websites"
+
+## Sites específicos {#specific-sites}
+
+- [ublacklist-pinterest](https://github.com/rjaus/ublacklist-pinterest) por [Riley James](https://github.com/rjaus)
+  - "ublacklist to block all pinterest websites from google, ddg, bing"
+- [ublacklist-w3schools](https://codeberg.org/Freso/ublacklist-w3schools) por [Freso](https://freso.dk/)
+  - "Hide W3Schools from search results"
+
+## Spam {#spam}
+
+- [Search Engine Spam Blocklist](https://github.com/no-cmyk/Search-Engine-Spam-Blocklist) por [no-cmyk](https://github.com/no-cmyk)
+  - "Blocklist to filter out spam and junk domains from search engines results"
+- [Super-SEO-Spam-Suppressor](https://github.com/NotaInutilis/Super-SEO-Spam-Suppressor) por [Nota Inutilis](https://github.com/NotaInutilis)
+  - "A blocklist targeting websites abusing SEO tactics to spam web searches with data pollution and security risks: content farms, scrapers, copycats, generative AIs, scams, advertisements, malwares, and useless garbage in general."
+- [SpamdexingSites](https://github.com/elliotwutingfeng/SpamdexingSites) por [Wu Tingfeng](https://github.com/elliotwutingfeng)
+  - "URL feed for blocking spamdexing websites."
+- [Ad and tracking server domain list](https://pgl.yoyo.org/adservers/) por [Peter Lowe](https://pgl.yoyo.org/)
+  - "Ad and tracking server domain list maintained since 2001."
+  - "Doesn’t have a dedicated uBlacklist/match patterns format, but use of the [`prepend`](https://pgl.yoyo.org/as/formats.php#prepend) and [`append`](https://pgl.yoyo.org/as/formats.php#append) parameters produce a URL that works perfectly for uBlacklist:
+  - "Não tem um formato em match patterns ou dedicado para o uBlacklist, mas o uso dos paramêtros [`prepend`](https://pgl.yoyo.org/as/formats.php#prepend) e [`append`](https://pgl.yoyo.org/as/formats.php#append) produzem um URL que funciona perfeitamente com o uBlacklist:
+    - "`https://pgl.yoyo.org/as/serverlist.php?hostformat=plain&mimetype=plaintext&prepend=*://*.&append=/*&showintro=0`"
+- [BadWebsiteBlocklist](https://github.com/popcar2/BadWebsiteBlocklist) por [popcar2](https://github.com/popcar2)
+  - Blocks AI generated spam, misleading advertisements, SEO bait, badware sites, and generally low-effort spam websites from your search engine results!
+
+## Jogos {#gaming}
+
+- [Safebrowsing for Minecrafters 🛡️⛏️](https://codeberg.org/legendary_creeper/safebrowsing-for-minecrafters) por [Legendary Creeper](https://craftodon.social/@legendary_creeper)
+  - "This filterlist was crafted to help users and creators in avoiding malicious Minecraft-related websites, including, but not limited to, those distributing malicious and illegal copies of the game or Mods, repost sites which monetize stolen content from creators, and sites impersonating trusted websites like Minecraft.net, CurseForge, or Mcpedl.com."
+
+## Chinês {#chinese}
+
+- [uBlacklist subscription compilation](https://github.com/eallion/uBlacklist-subscription-compilation) por [Charles Chin](https://github.com/eallion)
+  - "这是一个 uBlacklist 订阅地址合集，搜集了网上大部分的订阅地址合并成一个。"
+- [「小 X 知识百科网」清单](https://github.com/dallaslu/penzai-list) por [Dallas Lu](https://github.com/dallaslu)
+  - "List of content farm sites like g.penzai.com."
+- [ublacklist-rules](https://github.com/MisakaMikoto-35c5/ublacklist-rules) por [@MisakaMikoto-35c5](https://github.com/MisakaMikoto-35c5)
+  - content-farm.txt
+    - "清单中的网站大多为机器人爬虫网络采集而来的内容， 也可能包含一些人工撰写但质量低下的内容。"
+  - bad-content.txt
+    - "清单中的网站大多为用户体验极其不友好的网站。"
+  - not-friendly-captcha.txt
+    - "清单中的网站大多为根据 IP 所在国家/地理位置 来屏蔽普通用户的网站且不能认定内容有区域版权限制。"
+- [uBlacklist-Subscription](https://github.com/scyrte/uBlacklist-Subscription) por [Scyrte](https://github.com/scyrte)
+  - "使用它可以屏蔽一些垃圾网站占据你的搜索结果，比如卡饭教程、CSDN 等等。"
+- [終結內容農場 uBlacklist 黑名單](https://danny0838.github.io/content-farm-terminator/zh/subscriptions-ublacklist)
+  - 「終結內容農場」瀏覽器套件現在也提供 uBlacklist 格式的黑名單，包括標準內容農場、類內容農場、擴充內容農場、劣質複製農場等。
+- [电脑技术类型的白名单 whitelist](https://github.com/bcaso/Google-Chinese-Results-Whitelist) por [bcaso](https://github.com/bcaso)
+  - "白名单比更名单更高效，但是黑名单不能与白名单同时使用。"
+
+## Japonês {#japanese}
+
+- [uBlacklistRule](https://github.com/ncaq/uBlacklistRule) por [ncaq](https://github.com/ncaq)
+  - "技術系スパムサイト"
+  - "コピペサイト"
+  - "5ch のコピーサイト"
+  - "YouTube、ニコニコ動画などのコピーサイト"
+  - "コピーゲーム攻略サイト"
+  - "ゲハブログ"
+  - "その他検索の役に立たないサイト"
+- [ublacklist-programming-school](https://github.com/108EAA0A/ublacklist-programming-school) por [@108EAA0A](https://github.com/108EAA0A)
+  - "プログラミングスクールやその卒業生の低質な記事、スクール紹介サイトなどを除外する用"
+- [ublacklist-search-result](https://github.com/munierujp/ublacklist-search-result) por [@munierujp](https://github.com/munierujp)
+  - "SNS やショッピングサイトなどの検索結果ページを除外するための、uBlacklist のブラックリスト"
+- [ublacklist-scam-net-shops](https://github.com/exoego/ublacklist-scam-net-shops) por [@exoego](https://github.com/exoego)
+  - "怪しいネットショップを検索結果から除外"
+- [uBlacklist-filter-by-kdroidwin](https://github.com/Kdroidwin/uBlacklist-filter-by-kdroidwin) por [@Kdroidwin](https://github.com/Kdroidwin)
+  - "詐欺サイトや偽サイトやいかがでしたかサイトなどを検索結果から除外"
+
+## Outras listas de inscrição {#other-subscription-lists}
+
+- [awesome-ublacklist](https://github.com/rjaus/awesome-ublacklist) por [Riley James](https://github.com/rjaus)
+  - "Awesome list of uBlacklist subscriptions to block search results from google, bing, duckduckgo."
+- [Nicoles uBlacklist collection](https://github.com/nicoleahmed/nicoles-ublacklist/) por [Nicole Ahmed](https://github.com/nicoleahmed)
+  - "A collection of uBlacklist subscriptions in various languages and for multiple purposes. Additionally a small personal blacklist for sites missed by other lists (particularly UK related sites)."

--- a/i18n/pt-BR/docusaurus-theme-classic/footer.json
+++ b/i18n/pt-BR/docusaurus-theme-classic/footer.json
@@ -1,0 +1,5 @@
+{
+  "copyright": {
+    "message": "Direitos autorais © 2021 iorate. Construído com o Docusaurus."
+  }
+}

--- a/i18n/pt-BR/docusaurus-theme-classic/navbar.json
+++ b/i18n/pt-BR/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,14 @@
+{
+  "title": {
+    "message": "uBlacklist"
+  },
+  "item.label.docs": {
+    "message": "Documentação"
+  },
+  "item.label.subscriptions": {
+    "message": "Inscrições"
+  },
+  "item.label.privacyPolicy": {
+    "message": "Política de privacidade"
+  }
+}


### PR DESCRIPTION
- Not fully complete. Not sure if this is mergeable, so not spending too much time on it, but also there may be some additional work for these pages, maintaining them may be a pain with extra translations so... not doing them for now.
- Replace sections with English please, or get rid of the file when it makes sense.
- Portuguese (Brazil) is "Português (Brasil)" in the language itself. Or "Brazilian Portuguese" as "Português Brasileiro"