### PR TITLE
Added a domains list for Reworld Media Group

### DIFF
--- a/community/rulesets.yml
+++ b/community/rulesets.yml
@@ -177,6 +177,15 @@ chinese:
       url: https://github.com/bcaso
     subscription: https://raw.githubusercontent.com/bcaso/Computer-Science-Whitelist/main/whitelists/whitelist.txt
 
+french:
+  - name: Reworld Media
+    description: "Domains belonging to the Reworld Media group, known for monetizing the personal data of its readers for targeted advertising purposes."
+    homepage: https://github.com/benji1000/reworld-media-domain-list
+    author:
+      name: benji1000
+      url: https://github.com/benji1000
+    subscription: https://raw.githubusercontent.com/benji1000/reworld-media-domain-list/refs/heads/main/domains.txt
+
 italian:
   - name: Siti che subordinano l'accesso ai loro contenuti al pagamento di un abbonamento o all'accettazione di cookie
     description: "Blacklist di siti italiani che permettono di accedere ai loro contenuti solo dopo aver pagato un abbonamento o aver accettato i cookies. / Blacklist containing Italian sites that only allows accessing their content after buying a subscription or accepting their cookies."


### PR DESCRIPTION
Reworld Media group is known for monetizing the personal data of its readers for targeted advertising purposes.

More info (in French):

- Next - [Reworld Media peut « identifier une grossesse » et le revendre, en conformité avec le RGPD](https://next.ink/227970/pourquoi-reworld-media-et-prisma-publient-de-plus-en-plus-darticles-generes-par-ia/)
- Next - [Pourquoi Reworld Media et Prisma publient de plus en plus d’articles générés par IA](https://next.ink/228165/reworld-media-peut-identifier-une-grossesse-et-le-revendre-en-conformite-avec-le-rgpd/)