### PR TITLE
add Ruleset generator

### DIFF
--- a/community/rulesets.yml
+++ b/community/rulesets.yml
@@ -232,7 +232,7 @@ portuguese:
       url: https://codeberg.org/gmg48
     subscription: https://codeberg.org/gmg48/blocklist/raw/branch/main/ublacklist.txt
 
-other-ruleset-lists:
+other-resources:
   - name: awesome-ublacklist
     description: Awesome list of uBlacklist subscriptions to block search results from google, bing, duckduckgo.
     homepage: https://github.com/rjaus/awesome-ublacklist

--- a/community/rulesets.yml
+++ b/community/rulesets.yml
@@ -245,3 +245,9 @@ other-resources:
     author:
       name: Nicole Ahmed
       url: https://github.com/nicoleahmed
+  - name: Ruleset generator
+    description: Python script to generate rule sets. It takes a name like alamy and generates a list of pretty much every known domain, e.g., alamy.eu, alamy.de, etc, tries to resolve the names in parallel, and creates rules for the domains that are able to resolve.
+    homepage: https://codeberg.org/bananazon/ublacklist-generator
+    author:
+      name: Cursed Bananazon
+      url: https://codeberg.org/bananazon

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -45,7 +45,7 @@
   "pages.communityRulesets.portuguese": {
     "message": "Portuguese"
   },
-  "pages.communityRulesets.otherRulesetLists": {
-    "message": "Other ruleset lists"
+  "pages.communityRulesets.otherResources": {
+    "message": "Other resources"
   }
 }


### PR DESCRIPTION
- Add "Ruleset generator" (https://codeberg.org/bananazon/ublacklist-generator) proposed in iorate/ublacklist#768
- Rename the `other-ruleset-lists` section to `other-resources` so it can accommodate tools (not just lists) alongside awesome-ublacklist and Nicoles uBlacklist collection

Closes iorate/ublacklist#768