### PR TITLE
respect `prefer-color-scheme` of browser

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -81,6 +81,9 @@ const config: Config = {
     tableOfContents: {
       maxHeadingLevel: 4,
     },
+    colorMode: {
+      respectPrefersColorScheme: true,
+    },
   } satisfies Preset.ThemeConfig,
 
   future: {


### PR DESCRIPTION
https://docusaurus.io/docs/api/themes/configuration#respectPrefersColorScheme

When applied, if the device is in dark mode, the page will display in dark mode by default.

<span lang=ja>これを適用すると、端末がダークモードであれば初手ダークモードで表示されます。</span>

