### PR TITLE
ignore Claude Code files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ build
 
 # Generated files
 *.generated.ts
+
+# Claude Code
+.claude/settings.local.json
+.claude/worktrees/
+CLAUDE.local.md


### PR DESCRIPTION
Ignore local Claude Code artifacts (settings.local.json, worktrees/, CLAUDE.local.md) so contributors using Claude Code do not accidentally commit them.