### PR TITLE
rename "other resources" category to "resources"

### DIFF
--- a/community/rulesets.yml
+++ b/community/rulesets.yml
@@ -248,7 +248,7 @@ portuguese:
       url: https://codeberg.org/gmg48
     subscription: https://codeberg.org/gmg48/blocklist/raw/branch/main/ublacklist.txt
 
-other-resources:
+resources:
   - name: awesome-ublacklist
     description: Awesome list of uBlacklist subscriptions to block search results from google, bing, duckduckgo.
     homepage: https://github.com/rjaus/awesome-ublacklist

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -45,7 +45,7 @@
   "pages.communityRulesets.portuguese": {
     "message": "Portuguese"
   },
-  "pages.communityRulesets.otherResources": {
-    "message": "Other resources"
+  "pages.communityRulesets.resources": {
+    "message": "Resources"
   }
 }


### PR DESCRIPTION
## Summary
- Rename the `other-resources` category to `resources` in `community/rulesets.yml`.
- Update the corresponding i18n key (`pages.communityRulesets.otherResources` → `pages.communityRulesets.resources`) and message (`Other resources` → `Resources`) in `i18n/en/code.json`.
- `community/rulesets.generated.ts` already reflects the new key, so no regeneration is required.

## Test plan
- [ ] `pnpm check` passes.
- [ ] `pnpm start` renders the Community Rulesets page with the new "Resources" section heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)