### PR TITLE
add Microsoft Edge to supported browsers

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,12 @@ sidebar_position: 1
 
 ## Install
 
-You can install uBlacklist from [Chrome Web Store](https://chrome.google.com/webstore/detail/ublacklist/pncfbmialoiaghdehhbnbhkkgmjanfhe/), [Firefox Add-ons](https://addons.mozilla.org/en/firefox/addon/ublacklist/) or [App Store](https://apps.apple.com/us/app/ublacklist-for-safari/id1547912640).
+You can install uBlacklist from the following stores:
+
+- [Chrome Web Store](https://chrome.google.com/webstore/detail/ublacklist/pncfbmialoiaghdehhbnbhkkgmjanfhe/)
+- [Firefox Add-ons](https://addons.mozilla.org/en/firefox/addon/ublacklist/)
+- [Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/ublacklist/feedneoaheedjlhokipclogaoejelcbb)
+- [App Store](https://apps.apple.com/us/app/ublacklist-for-safari/id1547912640)
 
 :::note
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -4,10 +4,11 @@ sidebar_position: 0
 slug: /
 ---
 
-uBlacklist is a browser extension that filters Google Search results, available for Chrome, Firefox, and Safari.
+uBlacklist is a browser extension that filters Google Search results, available for Chrome, Firefox, Edge, and Safari.
 
 - [Chrome Web Store](https://chrome.google.com/webstore/detail/ublacklist/pncfbmialoiaghdehhbnbhkkgmjanfhe/)
 - [Firefox Add-ons](https://addons.mozilla.org/en/firefox/addon/ublacklist/)
+- [Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/ublacklist/feedneoaheedjlhokipclogaoejelcbb)
 - [App Store](https://apps.apple.com/us/app/ublacklist-for-safari/id1547912640) (maintained by [Group-Leafy](https://github.com/HoneyLuka/uBlacklist/tree/safari-port/safari-project))
 - [GitHub](https://github.com/iorate/ublacklist)
 


### PR DESCRIPTION
uBlacklist is now available on the Microsoft Edge Add-ons store. Add the Edge store link to the introduction and getting started pages.

The install section in getting-started.md is also rewritten from an inline sentence into a list to match the style of introduction.md.