### PR TITLE
Move minimumReleaseAgeExclude next to minimumReleaseAge

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,10 +1,10 @@
 pre-commit:
-  parallel: true
-  commands:
-    biome:
+  # Run serially: parallel `pnpm` invocations race on pnpm's deps-status check.
+  jobs:
+    - name: biome
       run: pnpm biome check --write --files-ignore-unknown=true --no-errors-on-unmatched {staged_files}
       stage_fixed: true
-    prettier:
+    - name: prettier
       glob: "*.{md,mdx,yaml,yml}"
       run: pnpm prettier --write {staged_files}
       stage_fixed: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,10 @@ blockExoticSubdeps: true
 
 minimumReleaseAge: 4320 # 3 days
 
+minimumReleaseAgeExclude:
+  # Renovate security update: js-yaml@4.2.0
+  - js-yaml@4.2.0
+
 overrides:
   serialize-javascript@<=7.0.2: ^7.0.3
   serialize-javascript@>=5.0.0 <7.0.5: ^7.0.5
@@ -19,6 +23,3 @@ trustPolicy: no-downgrade
 trustPolicyExclude:
   - detect-port@1.6.1
   - semver@6.3.1
-minimumReleaseAgeExclude:
-  # Renovate security update: js-yaml@4.2.0
-  - js-yaml@4.2.0


### PR DESCRIPTION
Renovate appended the `minimumReleaseAgeExclude` block to the bottom of `pnpm-workspace.yaml` when it created the js-yaml security update. Renovate only appends a fresh block when none exists; once the block is present it edits the existing node in place (via the `yaml` AST), so relocating it here is respected on subsequent runs.

Also switches lefthook's pre-commit from parallel `commands` to serial `jobs`, matching iorate/ublacklist — parallel `pnpm` invocations race on pnpm's deps-status check, which was breaking commits locally.