### PR TITLE
Update uuid override to 14.0.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   serialize-javascript@<=7.0.2: ^7.0.3
   serialize-javascript@>=5.0.0 <7.0.5: ^7.0.5
-  uuid@<11.1.1: ^11.1.1
+  uuid@<11.1.1: 14.0.1
 
 importers:
 
@@ -5669,8 +5669,8 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@11.1.1:
-    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
 
   value-equal@1.0.1:
@@ -12597,7 +12597,7 @@ snapshots:
   sockjs@0.3.24:
     dependencies:
       faye-websocket: 0.11.4
-      uuid: 11.1.1
+      uuid: 14.0.1
       websocket-driver: 0.7.4
 
   sort-css-media-queries@2.2.0: {}
@@ -12958,7 +12958,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@11.1.1: {}
+  uuid@14.0.1: {}
 
   value-equal@1.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,7 @@ minimumReleaseAgeExclude:
 overrides:
   serialize-javascript@<=7.0.2: ^7.0.3
   serialize-javascript@>=5.0.0 <7.0.5: ^7.0.5
-  uuid@<11.1.1: ^11.1.1
+  uuid@<11.1.1: 14.0.1
 
 trustPolicy: no-downgrade
 


### PR DESCRIPTION
Bump the transitive `uuid` override (pulled in by `sockjs` → `webpack-dev-server`, dev-server only) from `^11.1.1` to an exact `14.0.1`. This resolves both Renovate dashboard items for uuid at once: the `uuid@<11.1.1 to v14` update and the pin-dependencies request.

uuid is ESM-only since v12 (no CJS build), but `sockjs`'s `require('uuid').v4` still works via `require(ESM)` on the pinned Node 24 runtime. 14.0.1 is ~11 days old, so it clears the 3-day `minimumReleaseAge` cooldown.

Verified `pnpm start` boots and serves (HTTP 200) on Node 24.18.0.